### PR TITLE
If a file has no extension, place it into a folder

### DIFF
--- a/GroupFiles.ps1
+++ b/GroupFiles.ps1
@@ -32,7 +32,13 @@ function Get-DirectoryForFile{
         return $monthYearDirLookup[$modifiedTimeMonthYearInternal]
     }
 
-    $extensionWithoutDot = $file.Extension.Substring(1, $file.Extension.Length - 1)
+    #If the file has no extension, place it into a folder called "Other"
+    if($file.Extension.Length -eq 0) {
+        $extensionWithoutDot = "Other"
+    } else {
+        $extensionWithoutDot = $file.Extension.Substring(1, $file.Extension.Length - 1)
+    }
+    
     $dateFolderFileName = $file.LastWriteTime.ToString($folderDateTimeFormat)
     $newPath = $targetPath + "\" + $extensionWithoutDot + "\" + $dateFolderFileName
     $path = New-Item -ItemType Directory $newPath -Force

--- a/GroupFiles.ps1
+++ b/GroupFiles.ps1
@@ -32,9 +32,9 @@ function Get-DirectoryForFile{
         return $monthYearDirLookup[$modifiedTimeMonthYearInternal]
     }
 
-    #If the file has no extension, place it into a folder called "Other"
+    #If the file has no extension, place it into a folder called "No Extension"
     if($file.Extension.Length -eq 0) {
-        $extensionWithoutDot = "Other"
+        $extensionWithoutDot = "No Extension"
     } else {
         $extensionWithoutDot = $file.Extension.Substring(1, $file.Extension.Length - 1)
     }


### PR DESCRIPTION
When I ran the script, it encountered a file with no extension. The script crashed, the error being that the substring function on line 35 breaks when it is passed an empty string. This PR changes that part of the script so that it will place any files without extensions into a folder called "No Extension", rather than crashing.